### PR TITLE
Combine request logic

### DIFF
--- a/src/usps_client/models.py
+++ b/src/usps_client/models.py
@@ -20,6 +20,10 @@ def add_sub_element(parent, name, text):
 class Base(object):
     TAG = ""  # type: typing.Text
 
+    def __init__(self, **data):
+        # type: (typing.Optional[str]) -> None
+        super().__init__()
+
     def xml(self):
         # type: () -> etree.Element
         element = etree.Element(self.TAG)


### PR DESCRIPTION
Combine the shared behavior between request types into one set of methods. The methods implementing the API available to the user can now be extremely minimal.